### PR TITLE
Changed commands pipeline handling design

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/reeflective/console"
 	"github.com/spf13/cobra"
 )
 
 var app *console.Console
+
+var remainingCmds []string
 
 func GetCmds() *cobra.Command {
 	return rootCmd
@@ -13,6 +17,54 @@ func GetCmds() *cobra.Command {
 
 func StartInteractiveShell() {
 	app = console.New("ZShell")
+	// This hook will run every time when command is executed that includes command executed with ActiveMenu().RunCommandArgs
+	app.PostCmdRunHooks = []func() error{
+		func() error {
+			if len(remainingCmds) > 0 {
+				formattedCmds := formatCommand(remainingCmds)
+				if len(formattedCmds) > 1 {
+					fmt.Println("More commands present")
+					remainingCmds = formattedCmds[1]
+				} else {
+					remainingCmds = []string{} // Reached the end, Reset the remaining command
+				}
+				app.ActiveMenu().RunCommandArgs(app.ActiveMenu().Context(), formattedCmds[0])
+			}
+			return nil
+		},
+	}
+	// This hook run only once when the user enters a command
+	app.PreCmdRunLineHooks = []func(args []string) ([]string, error){
+		func(args []string) ([]string, error) {
+			formattedCmds := formatCommand(args)
+			if len(formattedCmds) > 1 {
+				remainingCmds = formattedCmds[1]
+			}
+			return formattedCmds[0], nil
+		},
+	}
 	app.ActiveMenu().SetCommands(GetCmds)
 	app.Start()
+}
+
+// Get the first command as one group and rest of them as another group
+func formatCommand(cmds []string) [][]string {
+	var result [][]string
+	var buffer []string
+
+	grouped := false
+
+	for _, cmd := range cmds {
+		if !grouped && cmd == "|" {
+			grouped = true
+			result = append(result, buffer)
+			buffer = []string{}
+			continue
+		}
+		buffer = append(buffer, cmd)
+	}
+
+	result = append(result, buffer)
+
+	return result
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,12 +13,6 @@ var rootCmd = &cobra.Command{
 	Use:     "zshell",
 	Version: "1.0",
 	Long:    "Zoho shell",
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 || args[0] != "|" {
-			return
-		}
-		app.ActiveMenu().RunCommandArgs(app.ActiveMenu().Context(), args[1:])
-	},
 }
 
 func createDefaultConfig(path string) error {


### PR DESCRIPTION
Handling the pipeline logic in the cobra side itself causes issues with flags handling. Like the below case,

When I run "account list | account list --dc $test"

The first **account list** command's dc flag should be affected. But when I use cobra's hooks the flags are being parsed at the initial stage. This causes a problem where we can't have each pipeline command scope level flags.

So moved this pipeline handling to the console package before running cobra for preventing the flag collisions.