### PR TITLE
Fix #12

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -29,7 +29,7 @@ var accountList = &cobra.Command{
 		accountsResp, httpResp, err := req.Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 		var rows []map[string]string
 		for _, account := range accountsResp.Data {
@@ -40,10 +40,10 @@ var accountList = &cobra.Command{
 			}
 			rows = append(rows, row)
 		}
-		lastCmdResult = &CmdResult{
+		SetLastCommandResult(&CmdResult{
 			header: []string{"Account Id", "Account Name", "Email"},
 			rows:   rows,
-		}
+		})
 	},
 }
 

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -83,7 +83,7 @@ var aliasListCmd = &cobra.Command{
 		if err != nil {
 			cobra.CheckErr(err)
 		}
-		lastCmdResult = &CmdResult{
+		lastCmdResult := &CmdResult{
 			header: []string{"Name", "Command", "Description"},
 		}
 		var rows []map[string]string
@@ -95,6 +95,7 @@ var aliasListCmd = &cobra.Command{
 			})
 		}
 		lastCmdResult.rows = rows
+		SetLastCommandResult(lastCmdResult)
 	},
 }
 

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -10,6 +10,7 @@ var displayCmd = &cobra.Command{
 	Short: "Display last command output",
 	Long:  "Display last command output",
 	Run: func(cmd *cobra.Command, args []string) {
+		lastCmdResult := GetLastCmdResult()
 		if lastCmdResult == nil {
 			return
 		}

--- a/cmd/folder.go
+++ b/cmd/folder.go
@@ -36,7 +36,7 @@ var folderListCmd = &cobra.Command{
 		foldersResponse, httpResp, err := client.FoldersAPI.GetAllFolders(ctx, accountId).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 
 		var rows []map[string]string
@@ -54,10 +54,10 @@ var folderListCmd = &cobra.Command{
 			})
 		}
 
-		lastCmdResult = &CmdResult{
+		SetLastCommandResult(&CmdResult{
 			header: []string{"Folder Id", "Folder Name", "Type", "Path", "Previous Folder"},
 			rows:   rows,
-		}
+		})
 	},
 }
 
@@ -119,7 +119,7 @@ var folderMoveCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.UpdateFolder(ctx, accountId, folderId).FolderUpdatePayload(*payload).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }
@@ -162,7 +162,7 @@ var folderRenameCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.UpdateFolder(ctx, accountId, folderId).FolderUpdatePayload(*payload).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }
@@ -192,7 +192,7 @@ var folderEnableImapCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.UpdateFolder(ctx, accountId, folderId).FolderUpdatePayload(*payload).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }
@@ -222,7 +222,7 @@ var folderDisableImapCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.UpdateFolder(ctx, accountId, folderId).FolderUpdatePayload(*payload).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }
@@ -252,7 +252,7 @@ var folderReadCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.UpdateFolder(ctx, accountId, folderId).FolderUpdatePayload(*payload).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }
@@ -282,7 +282,7 @@ var folderEmptyCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.UpdateFolder(ctx, accountId, folderId).FolderUpdatePayload(*payload).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }
@@ -311,7 +311,7 @@ var folderDeleteCmd = &cobra.Command{
 		_, httpResp, err := client.FoldersAPI.DeleteFolder(ctx, accountId, folderId).Execute()
 		if err != nil {
 			handleClientReqError(httpResp, err)
-      return
+			return
 		}
 	},
 }

--- a/cmd/head.go
+++ b/cmd/head.go
@@ -6,6 +6,7 @@ var headCmd = &cobra.Command{
 	Use:  "head",
 	Long: "Fetch the first n number of previous result rows",
 	Run: func(cmd *cobra.Command, args []string) {
+    lastCmdResult := GetLastCmdResult()
 		if lastCmdResult == nil {
 			return
 		}

--- a/cmd/noop.go
+++ b/cmd/noop.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var noopCmd = &cobra.Command{
+	Use:   "noop",
+	Short: "Does nothing",
+	Long:  "Does nothing",
+	Run: func(cmd *cobra.Command, args []string) {
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(noopCmd)
+}

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -1,11 +1,14 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 var tailCmd = &cobra.Command{
 	Use:  "tail",
 	Long: "Fetch the last n number of previous result rows",
 	Run: func(cmd *cobra.Command, args []string) {
+		lastCmdResult := GetLastCmdResult()
 		if lastCmdResult == nil {
 			return
 		}


### PR DESCRIPTION

Instead of using global variables using context to store the command piping info.

So now if I want to run a alias command which is used with other system commands. The alias command will run in a separate context then only its result will be copied to the current context.

Tested with multiple sub level alias commands. 